### PR TITLE
feat: GH workflow, use goccy/go-yaml, and use latest stable versions of go to test.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,34 @@
+name: Go checks
+
+on: pull_request
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Track only the latest 2 stable versions of Go.
+        go-version: ["1.23.x", "1.24.x"]
+      fail-fast: false
+
+    name: Go ${{ matrix.go-version }} Tests
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@main
+
+      - name: Set up Go ${{ matrix.go-version }}
+        uses: actions/setup-go@main
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Check build
+        run: go build -v ./...
+
+      - name: Run tests
+        run: go test -v ./...
+
+      - name: Run vulncheck
+        run: govulncheck ./...

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "mustache"]
 	path = mustache
-	url = git://github.com/mustache/spec.git
+	url = https://github.com/mustache/spec.git

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/mbleigh/raymond
 
-go 1.24.1
+go 1.23.8
 
-require gopkg.in/yaml.v2 v2.4.0
+require github.com/goccy/go-yaml v1.17.1

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+github.com/goccy/go-yaml v1.17.1 h1:LI34wktB2xEE3ONG/2Ar54+/HJVBriAGJ55PHls4YuY=
+github.com/goccy/go-yaml v1.17.1/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=

--- a/mustache_test.go
+++ b/mustache_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"gopkg.in/yaml.v2"
+	"github.com/goccy/go-yaml"
 )
 
 //


### PR DESCRIPTION
CHANGELOG:
- [ ] Add a github workflow for Go related checks.
- [ ] Update the YAML library to use goccy/go-yaml.
      https://github.com/go-yaml/yaml has been deprecated and archived.
- [ ] Use the latest 2 versions of go for testing.
- [ ] Fix submodule URL.
